### PR TITLE
Ms/add text shadow

### DIFF
--- a/schemas/v1.0.0.js
+++ b/schemas/v1.0.0.js
@@ -533,11 +533,6 @@ const schema = {
             },
             mime: {
                 type: 'string'
-            },
-            link: {
-                type: 'string',
-                description: 'The URL the video links to',
-                format: 'uri'
             }
         }, [
             'src',

--- a/schemas/v1.0.0.js
+++ b/schemas/v1.0.0.js
@@ -439,6 +439,9 @@ const schema = {
                     enum: ['overline', 'line-through', 'underline']
                 }
             },
+            text_shadow: {
+                type: 'string'
+            },
             text_prevent_widow: {
                 type: 'boolean'
             },
@@ -530,6 +533,11 @@ const schema = {
             },
             mime: {
                 type: 'string'
+            },
+            link: {
+                type: 'string',
+                description: 'The URL the video links to',
+                format: 'uri'
             }
         }, [
             'src',

--- a/schemas/v1.0.0.json
+++ b/schemas/v1.0.0.json
@@ -959,6 +959,9 @@
                         ]
                     }
                 },
+                "text_shadow": {
+                    "type": "string"
+                },
                 "text_prevent_widow": {
                     "type": "boolean"
                 },


### PR DESCRIPTION
The new property `text_shadow` allows the format to render complex shadows defined as string that consist of many (x,y,r,hex) combinations and thereby allow the formation of composite shadows.